### PR TITLE
Duplicate backoff settings before making request

### DIFF
--- a/httpbackoff.go
+++ b/httpbackoff.go
@@ -115,8 +115,18 @@ func Retry(httpCall func() (resp *http.Response, tempError error, permError erro
 		return nil
 	}
 
+	// Duplicate backoff settings to avoid race conditions when used for concurrent requests.
+	backoffSettings := &backoff.ExponentialBackOff{
+		InitialInterval:     BackOffSettings.InitialInterval,
+		RandomizationFactor: BackOffSettings.RandomizationFactor,
+		Multiplier:          BackOffSettings.Multiplier,
+		MaxInterval:         BackOffSettings.MaxInterval,
+		MaxElapsedTime:      BackOffSettings.MaxElapsedTime,
+		Clock:               BackOffSettings.Clock,
+	}
+
 	// Make HTTP API calls using an exponential backoff algorithm...
-	backoff.RetryNotify(doHttpCall, BackOffSettings, func(err error, wait time.Duration) {
+	backoff.RetryNotify(doHttpCall, backoffSettings, func(err error, wait time.Duration) {
 		log.Printf("Error: %s", err)
 	})
 

--- a/httpbackoff.go
+++ b/httpbackoff.go
@@ -26,14 +26,13 @@
 //
 // This can be rewritten as follows, enabling automatic retries:
 //
-//  res, attempts, err := httpbackoff.New().Get("http://www.google.com/robots.txt")
+//  res, attempts, err := httpbackoff.Get("http://www.google.com/robots.txt")
 //
 // The variable attempts stores the number of http calls that were made (one
 // plus the number of retries).
 package httpbackoff
 
 import (
-	"bufio"
 	"io"
 	"log"
 	"net/http"
@@ -45,11 +44,12 @@ import (
 	"github.com/cenkalti/backoff"
 )
 
-type ExponentialBackOff backoff.ExponentialBackOff
+var defaultClient Client = Client{
+	BackOffSettings: backoff.NewExponentialBackOff(),
+}
 
-func New() *ExponentialBackOff {
-	x := ExponentialBackOff(*backoff.NewExponentialBackOff())
-	return &x
+type Client struct {
+	BackOffSettings *backoff.ExponentialBackOff
 }
 
 // Any non 2xx HTTP status code is considered a bad response code, and will
@@ -77,7 +77,7 @@ func (err BadHttpResponseCode) Error() string {
 // since Retry will take care of it.
 //
 // Concurrent use of this library method is supported.
-func (backOffSettings *ExponentialBackOff) Retry(httpCall func() (resp *http.Response, tempError error, permError error)) (*http.Response, int, error) {
+func (httpRetryClient *Client) Retry(httpCall func() (resp *http.Response, tempError error, permError error)) (*http.Response, int, error) {
 	var tempError, permError error
 	var response *http.Response
 	attempts := 0
@@ -115,7 +115,7 @@ func (backOffSettings *ExponentialBackOff) Retry(httpCall func() (resp *http.Res
 	}
 
 	// Make HTTP API calls using an exponential backoff algorithm...
-	b := backoff.ExponentialBackOff(*backOffSettings)
+	b := backoff.ExponentialBackOff(*httpRetryClient.BackOffSettings)
 	backoff.RetryNotify(doHttpCall, &b, func(err error, wait time.Duration) {
 		log.Printf("Error: %s", err)
 	})
@@ -130,101 +130,147 @@ func (backOffSettings *ExponentialBackOff) Retry(httpCall func() (resp *http.Res
 	}
 }
 
+// Retry works the same as HTTPRetryClient.Retry, but uses the default exponential back off settings
+func Retry(httpCall func() (resp *http.Response, tempError error, permError error)) (*http.Response, int, error) {
+	return defaultClient.Retry(httpCall)
+}
+
 // Retry wrapper for http://golang.org/pkg/net/http/#Get where attempts is the number of http calls made (one plus number of retries).
-func (backOffSettings *ExponentialBackOff) Get(url string) (resp *http.Response, attempts int, err error) {
-	return backOffSettings.Retry(func() (*http.Response, error, error) {
+func (httpRetryClient *Client) Get(url string) (resp *http.Response, attempts int, err error) {
+	return httpRetryClient.Retry(func() (*http.Response, error, error) {
 		resp, err := http.Get(url)
 		// assume all errors should result in a retry
 		return resp, err, nil
 	})
 }
 
+// Get works the same as HTTPRetryClient.Get, but uses the default exponential back off settings
+func Get(url string) (resp *http.Response, attempts int, err error) {
+	return defaultClient.Get(url)
+}
+
 // Retry wrapper for http://golang.org/pkg/net/http/#Head where attempts is the number of http calls made (one plus number of retries).
-func (backOffSettings *ExponentialBackOff) Head(url string) (resp *http.Response, attempts int, err error) {
-	return backOffSettings.Retry(func() (*http.Response, error, error) {
+func (httpRetryClient *Client) Head(url string) (resp *http.Response, attempts int, err error) {
+	return httpRetryClient.Retry(func() (*http.Response, error, error) {
 		resp, err := http.Head(url)
 		// assume all errors should result in a retry
 		return resp, err, nil
 	})
 }
 
+// Head works the same as HTTPRetryClient.Head, but uses the default exponential back off settings
+func Head(url string) (resp *http.Response, attempts int, err error) {
+	return defaultClient.Head(url)
+}
+
 // Retry wrapper for http://golang.org/pkg/net/http/#Post where attempts is the number of http calls made (one plus number of retries).
-func (backOffSettings *ExponentialBackOff) Post(url string, bodyType string, body io.Reader) (resp *http.Response, attempts int, err error) {
-	return backOffSettings.Retry(func() (*http.Response, error, error) {
+func (httpRetryClient *Client) Post(url string, bodyType string, body io.Reader) (resp *http.Response, attempts int, err error) {
+	return httpRetryClient.Retry(func() (*http.Response, error, error) {
 		resp, err := http.Post(url, bodyType, body)
 		// assume all errors should result in a retry
 		return resp, err, nil
 	})
 }
 
+// Post works the same as HTTPRetryClient.Post, but uses the default exponential back off settings
+func Post(url string, bodyType string, body io.Reader) (resp *http.Response, attempts int, err error) {
+	return defaultClient.Post(url, bodyType, body)
+}
+
 // Retry wrapper for http://golang.org/pkg/net/http/#PostForm where attempts is the number of http calls made (one plus number of retries).
-func (backOffSettings *ExponentialBackOff) PostForm(url string, data url.Values) (resp *http.Response, attempts int, err error) {
-	return backOffSettings.Retry(func() (*http.Response, error, error) {
+func (httpRetryClient *Client) PostForm(url string, data url.Values) (resp *http.Response, attempts int, err error) {
+	return httpRetryClient.Retry(func() (*http.Response, error, error) {
 		resp, err := http.PostForm(url, data)
 		// assume all errors should result in a retry
 		return resp, err, nil
 	})
 }
 
-// Retry wrapper for http://golang.org/pkg/net/http/#ReadResponse where attempts is the number of http calls made (one plus number of retries).
-func (backOffSettings *ExponentialBackOff) ReadResponse(r *bufio.Reader, req *http.Request) (resp *http.Response, attempts int, err error) {
-	return backOffSettings.Retry(func() (*http.Response, error, error) {
-		resp, err := http.ReadResponse(r, req)
-		// assume all errors should result in a retry
-		return resp, err, nil
-	})
+// PostForm works the same as HTTPRetryClient.PostForm, but uses the default exponential back off settings
+func PostForm(url string, data url.Values) (resp *http.Response, attempts int, err error) {
+	return defaultClient.PostForm(url, data)
 }
 
 // Retry wrapper for http://golang.org/pkg/net/http/#Client.Do where attempts is the number of http calls made (one plus number of retries).
-func (backOffSettings *ExponentialBackOff) ClientDo(c *http.Client, req *http.Request) (resp *http.Response, attempts int, err error) {
-	return backOffSettings.Retry(func() (*http.Response, error, error) {
+func (httpRetryClient *Client) ClientDo(c *http.Client, req *http.Request) (resp *http.Response, attempts int, err error) {
+	return httpRetryClient.Retry(func() (*http.Response, error, error) {
 		resp, err := c.Do(req)
 		// assume all errors should result in a retry
 		return resp, err, nil
 	})
 }
 
+// ClientDo works the same as HTTPRetryClient.ClientDo, but uses the default exponential back off settings
+func ClientDo(c *http.Client, req *http.Request) (resp *http.Response, attempts int, err error) {
+	return defaultClient.ClientDo(c, req)
+}
+
 // Retry wrapper for http://golang.org/pkg/net/http/#Client.Get where attempts is the number of http calls made (one plus number of retries).
-func (backOffSettings *ExponentialBackOff) ClientGet(c *http.Client, url string) (resp *http.Response, attempts int, err error) {
-	return backOffSettings.Retry(func() (*http.Response, error, error) {
+func (httpRetryClient *Client) ClientGet(c *http.Client, url string) (resp *http.Response, attempts int, err error) {
+	return httpRetryClient.Retry(func() (*http.Response, error, error) {
 		resp, err := c.Get(url)
 		// assume all errors should result in a retry
 		return resp, err, nil
 	})
 }
 
+// ClientGet works the same as HTTPRetryClient.ClientGet, but uses the default exponential back off settings
+func ClientGet(c *http.Client, url string) (resp *http.Response, attempts int, err error) {
+	return defaultClient.ClientGet(c, url)
+}
+
 // Retry wrapper for http://golang.org/pkg/net/http/#Client.Head where attempts is the number of http calls made (one plus number of retries).
-func (backOffSettings *ExponentialBackOff) ClientHead(c *http.Client, url string) (resp *http.Response, attempts int, err error) {
-	return backOffSettings.Retry(func() (*http.Response, error, error) {
+func (httpRetryClient *Client) ClientHead(c *http.Client, url string) (resp *http.Response, attempts int, err error) {
+	return httpRetryClient.Retry(func() (*http.Response, error, error) {
 		resp, err := c.Head(url)
 		// assume all errors should result in a retry
 		return resp, err, nil
 	})
 }
 
+// ClientHead works the same as HTTPRetryClient.ClientHead, but uses the default exponential back off settings
+func ClientHead(c *http.Client, url string) (resp *http.Response, attempts int, err error) {
+	return defaultClient.ClientHead(c, url)
+}
+
 // Retry wrapper for http://golang.org/pkg/net/http/#Client.Post where attempts is the number of http calls made (one plus number of retries).
-func (backOffSettings *ExponentialBackOff) ClientPost(c *http.Client, url string, bodyType string, body io.Reader) (resp *http.Response, attempts int, err error) {
-	return backOffSettings.Retry(func() (*http.Response, error, error) {
+func (httpRetryClient *Client) ClientPost(c *http.Client, url string, bodyType string, body io.Reader) (resp *http.Response, attempts int, err error) {
+	return httpRetryClient.Retry(func() (*http.Response, error, error) {
 		resp, err := c.Post(url, bodyType, body)
 		// assume all errors should result in a retry
 		return resp, err, nil
 	})
 }
 
+// ClientPost works the same as HTTPRetryClient.ClientPost, but uses the default exponential back off settings
+func ClientPost(c *http.Client, url string, bodyType string, body io.Reader) (resp *http.Response, attempts int, err error) {
+	return defaultClient.ClientPost(c, url, bodyType, body)
+}
+
 // Retry wrapper for http://golang.org/pkg/net/http/#Client.PostForm where attempts is the number of http calls made (one plus number of retries).
-func (backOffSettings *ExponentialBackOff) ClientPostForm(c *http.Client, url string, data url.Values) (resp *http.Response, attempts int, err error) {
-	return backOffSettings.Retry(func() (*http.Response, error, error) {
+func (httpRetryClient *Client) ClientPostForm(c *http.Client, url string, data url.Values) (resp *http.Response, attempts int, err error) {
+	return httpRetryClient.Retry(func() (*http.Response, error, error) {
 		resp, err := c.PostForm(url, data)
 		// assume all errors should result in a retry
 		return resp, err, nil
 	})
 }
 
+// ClientPostForm works the same as HTTPRetryClient.ClientPostForm, but uses the default exponential back off settings
+func ClientPostForm(c *http.Client, url string, data url.Values) (resp *http.Response, attempts int, err error) {
+	return defaultClient.ClientPostForm(c, url, data)
+}
+
 // Retry wrapper for http://golang.org/pkg/net/http/#Transport.RoundTrip where attempts is the number of http calls made (one plus number of retries).
-func (backOffSettings *ExponentialBackOff) RoundTrip(t *http.Transport, req *http.Request) (resp *http.Response, attempts int, err error) {
-	return backOffSettings.Retry(func() (*http.Response, error, error) {
+func (httpRetryClient *Client) RoundTrip(t *http.Transport, req *http.Request) (resp *http.Response, attempts int, err error) {
+	return httpRetryClient.Retry(func() (*http.Response, error, error) {
 		resp, err := t.RoundTrip(req)
 		// assume all errors should result in a retry
 		return resp, err, nil
 	})
+}
+
+// RoundTrip works the same as HTTPRetryClient.RoundTrip, but uses the default exponential back off settings
+func RoundTrip(t *http.Transport, req *http.Request) (resp *http.Response, attempts int, err error) {
+	return defaultClient.RoundTrip(t, req)
 }

--- a/retry_test.go
+++ b/retry_test.go
@@ -20,7 +20,7 @@ func TestRetry5xx(t *testing.T) {
 	// defer clean up in case we have t.Fatalf calls
 	defer handler.ClearResponseQueue()
 
-	resp, _, err := Get("http://localhost:50849/TestRetry5xx")
+	resp, _, err := backOffSettings.Get("http://localhost:50849/TestRetry5xx")
 
 	if err != nil {
 		t.Fatalf("%v\n", err)
@@ -39,7 +39,7 @@ func TestRetry4xx(t *testing.T) {
 	// defer clean up in case we have t.Fatalf calls
 	defer handler.ClearResponseQueue()
 
-	resp, _, err := Get("http://localhost:50849/TestRetry4xx")
+	resp, _, err := backOffSettings.Get("http://localhost:50849/TestRetry4xx")
 
 	// NB: this is == not != since we *want* an error
 	if err == nil {
@@ -55,7 +55,7 @@ func TestRetry4xx(t *testing.T) {
 func TestNetworkFailure(t *testing.T) {
 
 	// bad port
-	_, attempts, err := Get("http://localhost:40849/TestNetworkFailure")
+	_, attempts, err := backOffSettings.Get("http://localhost:40849/TestNetworkFailure")
 
 	// NB: this is == not != since we *want* an error
 	if err == nil {

--- a/retry_test.go
+++ b/retry_test.go
@@ -20,7 +20,7 @@ func TestRetry5xx(t *testing.T) {
 	// defer clean up in case we have t.Fatalf calls
 	defer handler.ClearResponseQueue()
 
-	resp, _, err := backOffSettings.Get("http://localhost:50849/TestRetry5xx")
+	resp, _, err := testClient.Get("http://localhost:50849/TestRetry5xx")
 
 	if err != nil {
 		t.Fatalf("%v\n", err)
@@ -39,7 +39,7 @@ func TestRetry4xx(t *testing.T) {
 	// defer clean up in case we have t.Fatalf calls
 	defer handler.ClearResponseQueue()
 
-	resp, _, err := backOffSettings.Get("http://localhost:50849/TestRetry4xx")
+	resp, _, err := testClient.Get("http://localhost:50849/TestRetry4xx")
 
 	// NB: this is == not != since we *want* an error
 	if err == nil {
@@ -55,7 +55,7 @@ func TestRetry4xx(t *testing.T) {
 func TestNetworkFailure(t *testing.T) {
 
 	// bad port
-	_, attempts, err := backOffSettings.Get("http://localhost:40849/TestNetworkFailure")
+	_, attempts, err := testClient.Get("http://localhost:40849/TestNetworkFailure")
 
 	// NB: this is == not != since we *want* an error
 	if err == nil {

--- a/test_setup_test.go
+++ b/test_setup_test.go
@@ -2,13 +2,14 @@ package httpbackoff
 
 import (
 	"fmt"
-	"github.com/cenkalti/backoff"
 	"io"
 	"net"
 	"net/http"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/cenkalti/backoff"
 )
 
 var (
@@ -87,8 +88,8 @@ func TestMain(m *testing.M) {
 // start up http service
 func startServingHTTP() error {
 	handler = NewMyHandler()
-	server = &http.Server{Addr: ":50849", Handler: handler}
-	listener, err = net.Listen("tcp", ":50849")
+	server = &http.Server{Addr: "localhost:50849", Handler: handler}
+	listener, err = net.Listen("tcp", "localhost:50849")
 	return err
 }
 

--- a/test_setup_test.go
+++ b/test_setup_test.go
@@ -13,11 +13,11 @@ import (
 )
 
 var (
-	err             error
-	handler         *MyHandler
-	listener        net.Listener
-	server          *http.Server
-	backOffSettings *ExponentialBackOff
+	err        error
+	handler    *MyHandler
+	listener   net.Listener
+	server     *http.Server
+	testClient *Client
 )
 
 // Handler for stubbing http requests from auth API endpoint
@@ -55,13 +55,15 @@ func NewMyHandler() *MyHandler {
 func TestMain(m *testing.M) {
 
 	// Set up appropriate backoff settings to tests run quickly...
-	backOffSettings = &ExponentialBackOff{
-		InitialInterval:     1 * time.Millisecond,
-		RandomizationFactor: 0.2,
-		Multiplier:          1.2,
-		MaxInterval:         5 * time.Millisecond,
-		MaxElapsedTime:      20 * time.Millisecond,
-		Clock:               backoff.SystemClock,
+	testClient = &Client{
+		BackOffSettings: &backoff.ExponentialBackOff{
+			InitialInterval:     1 * time.Millisecond,
+			RandomizationFactor: 0.2,
+			Multiplier:          1.2,
+			MaxInterval:         5 * time.Millisecond,
+			MaxElapsedTime:      20 * time.Millisecond,
+			Clock:               backoff.SystemClock,
+		},
 	}
 
 	err = startServingHTTP()

--- a/test_setup_test.go
+++ b/test_setup_test.go
@@ -13,10 +13,11 @@ import (
 )
 
 var (
-	err      error
-	handler  *MyHandler
-	listener net.Listener
-	server   *http.Server
+	err             error
+	handler         *MyHandler
+	listener        net.Listener
+	server          *http.Server
+	backOffSettings *ExponentialBackOff
 )
 
 // Handler for stubbing http requests from auth API endpoint
@@ -54,7 +55,7 @@ func NewMyHandler() *MyHandler {
 func TestMain(m *testing.M) {
 
 	// Set up appropriate backoff settings to tests run quickly...
-	BackOffSettings = &backoff.ExponentialBackOff{
+	backOffSettings = &ExponentialBackOff{
 		InitialInterval:     1 * time.Millisecond,
 		RandomizationFactor: 0.2,
 		Multiplier:          1.2,


### PR DESCRIPTION
backoff settings has some fields that get updated within the httpbackoff library when making the request that are not safe for concurrent requests. 