### PR TITLE
Bug 1394536 - Explicitly unset Accept-Encoding header

### DIFF
--- a/httpbackoff.go
+++ b/httpbackoff.go
@@ -206,6 +206,16 @@ func (httpRetryClient *Client) ClientDo(c *http.Client, req *http.Request) (resp
 		newReq, err := http.ReadRequest(bufio.NewReader(bytes.NewBuffer(rawReq)))
 		newReq.RequestURI = ""
 		newReq.URL = req.URL
+		// If the original request doesn't explicitly set Accept-Encoding, then
+		// the go standard library will add it, and allow gzip compression, and
+		// magically unzip the response transparently. This wouldn't be too
+		// much of a problem, except that if the header is explicitly set, then
+		// the standard library won't automatically unzip the response. This is
+		// arguably a bug in the standard library but we'll work around it by
+		// checking this specific condition.
+		if req.Header.Get("Accept-Encoding") == "" {
+			newReq.Header.Del("Accept-Encoding")
+		}
 		if err != nil {
 			return nil, nil, err // fatal
 		}


### PR DESCRIPTION
This is arguably a bug in the go standard library, but I've created a workaround (and will consider following up with a go stdlib bug report / patch).

The go standard library does some magic. If you compose a request that doesn't contain the 'Accept-Encoding' header, when making the http request, it may get added to the request for you. On returning the http response, the stdlib will then unzip the response for you, so as a user of the library, it all happened transparently and magically, without you knowing about it.

The problem comes in the httpbackoff library, that was designed to replay http requests if an intermittent error occurs. It caches the http request (since the underlying request uses an io.Reader to stream the request body). If we didn't cache the request body, after making the request once, the content of the request body would be gone, and we wouldn't be able to replay the request.

We read the cached copy of the original request into a new request, using the https://golang.org/pkg/net/http/#ReadRequest function. The problem with this, is this new request now has Accept-Encoding header explicitly set, even though it was not set in the original request. This then changes the underlying behaviour of the http package, not to magically decompress the response body, and thus, we end up with gzipped contents, even though at no point we mentioned anything about gzip compression or decompression in our code.

The solution I have applied, is to simply check whether the original request has the Accept-Encoding header explicitly set, and if not, we remove the header from the newly generated request, since it could only have been set by the standard library, not by the code that generated the request object.