### PR TITLE
Upgrade to go1.12, backoff v3, release v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.11
+  - 1.12
 
 before_install:
   - go get github.com/axw/gocov/gocov

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/taskcluster/httpbackoff/v3
+
+require github.com/cenkalti/backoff/v3 v3.0.0
+
+go 1.12

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=
+github.com/cenkalti/backoff/v3 v3.0.0/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=

--- a/httpbackoff.go
+++ b/httpbackoff.go
@@ -42,7 +42,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v3"
 )
 
 var defaultClient Client = Client{

--- a/test_setup_test.go
+++ b/test_setup_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cenkalti/backoff"
+	"github.com/cenkalti/backoff/v3"
 )
 
 var (


### PR DESCRIPTION
I think it would make sense to track cenkalti's major versions in this package, so I went straight to v3.

Fixes #10