### PR TITLE
add @petemoore as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# see http://code.v.igoro.us/posts/2019/07/codeowners.html
+
+* @petemoore


### PR DESCRIPTION
We could also make this point to @taskcluster/worker-reviewers or maybe create a new @taskcluster/golang-reviewers?